### PR TITLE
Update qnode.hpp

### DIFF
--- a/include/cyrobot_monitor/qnode.hpp
+++ b/include/cyrobot_monitor/qnode.hpp
@@ -145,8 +145,8 @@ class QNode : public QThread {
   int m_threadNum = 4;
   int m_frameRate = 40;
   //地图 0 0点坐标对应世界坐标系的坐标
-  int m_mapOriginX;
-  int m_mapOriginY;
+  float m_mapOriginX;
+  float m_mapOriginY;
   //地图坐标系中心点坐标
   QPointF m_mapCenterPoint;
   //图元坐标系中心点坐标


### PR DESCRIPTION
修改了地图原点对应坐标系坐标的数据类型（int转为flaot）,调试时发现雷达数据与实际地图有偏差，修改后偏差消失，由于从地图的yaml文件中读取的原点并非都是整数。